### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v2.0.0] - 2020-10-28
+
+### Added
+
+- FEAT([9](https://github.com/meateam/permission-service/pull/9)): RPC method GetPermissionByMongoID
+
+### Fixed
+
+- BUG([195](https://github.com/meateam/permission-service/issues/195)): uploads with same `fileName-parntID-ownerID` cannot exist simultaneously.
+
+## [Unreleased]
+
+[unreleased]: https://github.com/meateam/permission-service/compare/master...develop
+[v2.0.0]: https://github.com/meateam/permission-service/compare/v1.3...v2.0.0


### PR DESCRIPTION
Updated CHANGELOG.md:

## [v2.0.0] - 2020-10-28

### Added

- FEAT([9](https://github.com/meateam/permission-service/pull/9)): RPC method GetPermissionByMongoID

[v2.0.0]: https://github.com/meateam/permission-service/compare/v1.3...v2.0.0

Signed-off-by: shahar-y <shya95@gmail.com>